### PR TITLE
Allowing buzz upgrade to recent version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 before_script:
     - composer self-update
-    - composer install --prefer-source --no-interaction
+    - composer install --no-interaction --no-progress --no-suggest
 
 script:
     - bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "kriswallsmith/buzz": "0.10"
+        "kriswallsmith/buzz": "^0.15"
     },
     "require-dev": {
         "phpspec/phpspec": "^3.0",


### PR DESCRIPTION
Upgrading `kriswallsmith/Buzz` to `^0.15` that brings numerous patches to the package plus PSR-4 transition from PSR-0, as well as PHP7 compatibility
  