### PR TITLE
Make the error handling more robust 

### DIFF
--- a/spec/Exception/RequestExceptionSpec.php
+++ b/spec/Exception/RequestExceptionSpec.php
@@ -11,13 +11,11 @@ class RequestExceptionSpec extends ObjectBehavior
 {
     function let()
     {
-        $response = array('error' => array('code' => 404, 'message' => 'Room not found', 'type' => 'Not found'));
-        $this->beConstructedWith($response);
+        $this->beConstructedWith('Room not found', 404, 'Not found');
     }
     function it_is_initializable()
     {
         $this->shouldHaveType(RequestException::class);
-
         $this->shouldImplement(RequestExceptionInterface::class);
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -51,7 +51,7 @@ class Client implements ClientInterface
         try {
             $response = $this->browser->get($url, $headers);
         } catch (\Buzz\Exception\ClientException $e) {
-            throw new RequestException($e->getMessage());
+            throw new RequestException($e->getMessage(), $e->getCode(), '', $e);
         }
 
         $this->checkBrowserResponse();
@@ -74,7 +74,7 @@ class Client implements ClientInterface
         try {
             $response = $this->browser->post($url, $headers, json_encode($content));
         } catch (\Buzz\Exception\ClientException $e) {
-            throw new RequestException($e->getMessage());
+            throw new RequestException($e->getMessage(), $e->getCode(), '', $e);
         }
 
         $this->checkBrowserResponse();
@@ -96,7 +96,7 @@ class Client implements ClientInterface
         try {
             $response = $this->browser->put($url, $headers, json_encode($content));
         } catch (\Buzz\Exception\ClientException $e) {
-            throw new RequestException($e->getMessage());
+            throw new RequestException($e->getMessage(), $e->getCode(), '', $e);
         }
 
         $this->checkBrowserResponse();
@@ -118,7 +118,7 @@ class Client implements ClientInterface
         try {
             $response = $this->browser->delete($url, $headers);
         } catch (\Buzz\Exception\ClientException $e) {
-            throw new RequestException($e->getMessage());
+            throw new RequestException($e->getMessage(), $e->getCode(), '', $e);
         }
 
         $this->checkBrowserResponse();
@@ -153,7 +153,11 @@ class Client implements ClientInterface
     private function checkBrowserResponse()
     {
         if ($this->browser->getLastResponse()->getStatusCode() > 299) {
-            throw new RequestException(json_decode($this->browser->getLastResponse()->getContent(), true));
+            $response = json_decode($this->browser->getLastResponse()->getContent(), true);
+            $code = isset($response['error']['code']) ? $response['error']['code'] : 0;
+            $message = isset($response['error']['message']) ? $response['error']['message'] : '';
+            $type = isset($response['error']['type']) ? $response['error']['type'] : '';
+            throw new RequestException($message, $code, $type);
         }
     }
 }

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -1,13 +1,8 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: gorkalaucirica
- * Date: 09/07/14
- * Time: 12:33
- */
 
 namespace SolutionDrive\HipchatAPIv2Client\Exception;
 
+use Throwable;
 
 class RequestException extends \Exception implements RequestExceptionInterface
 {
@@ -20,31 +15,16 @@ class RequestException extends \Exception implements RequestExceptionInterface
     /**
      * Request exception constructor
      *
-     * @param string $response json_decoded array with the error response given by the server
+     * @param string $message
+     * @param int $code
+     * @param string $type
+     * @param Throwable|null $previous
      */
-    public function __construct($response)
+    public function __construct($message = "", $code = 0, $type = '', Throwable $previous = null)
     {
-        $message = '';
-        $code = null;
-        $type = null;
-        if (is_string($response)) {
-            $message = $response;
-        } elseif (is_array($response)) {
-            $error = isset($response['error']) ? $response['error'] : '';
-            if (isset($error['code'])) {
-                $code = $error['code'];
-            }
-            if (isset($error['message'])) {
-                $message = $error['message'];
-            }
-            if (isset($error['type'])) {
-                $type = $error['type'];
-            }
-        }
-
         $this->responseCode = $code;
         $this->type = $type;
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 
     /**

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -24,10 +24,27 @@ class RequestException extends \Exception implements RequestExceptionInterface
      */
     public function __construct($response)
     {
-        $error = $response['error'];
-        $this->responseCode = $error['code'];
-        $this->message = $error['message'];
-        $this->type = $error['type'];
+        $message = '';
+        $code = null;
+        $type = null;
+        if (is_string($response)) {
+            $message = $response;
+        } elseif (is_array($response)) {
+            $error = isset($response['error']) ? $response['error'] : '';
+            if (isset($error['code'])) {
+                $code = $error['code'];
+            }
+            if (isset($error['message'])) {
+                $message = $error['message'];
+            }
+            if (isset($error['type'])) {
+                $type = $error['type'];
+            }
+        }
+
+        $this->responseCode = $code;
+        $this->type = $type;
+        parent::__construct($message, $code);
     }
 
     /**


### PR DESCRIPTION
Only one exception actually passes an array as response value to the RequestException. In the other cases only the exception string is passed. This can lead to PHP warnings.

I tried to make the handling of the response parameter a bit more robust to not throw warnings.